### PR TITLE
feat: adds video preview handling

### DIFF
--- a/src-tauri/src/capturer/mod.rs
+++ b/src-tauri/src/capturer/mod.rs
@@ -1,7 +1,6 @@
 // use scap::capturer::{Capturer, Options};
 use crate::{AppState, Status};
-use std::sync::Arc;
-use tauri::{AppHandle, Manager};
+use tauri::{api::path::desktop_dir, AppHandle, Manager};
 use tokio::sync::Mutex;
 
 #[tauri::command]
@@ -17,7 +16,7 @@ pub async fn start_capture(area: Vec<u32>, app_handle: AppHandle) {
     state.status = Status::Recording;
 
     // TEMP: stop capturing after 5 seconds, to get to editor
-    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
     stop_capture(app_handle.clone()).await;
     println!("complete"); // this never runs
 }
@@ -26,12 +25,16 @@ pub async fn start_capture(area: Vec<u32>, app_handle: AppHandle) {
 pub async fn stop_capture(app_handle: AppHandle) {
     println!("Capture stopped");
     app_handle.emit_all("capture-stopped", false).unwrap();
+    crate::cropper::toggle_cropper(&app_handle);
 
     // TODO: stop capturing with scap
 
-    // Hide cropper, create editor
-    crate::cropper::toggle_cropper(&app_handle);
-    crate::editor::init_editor(&app_handle);
+    // INFO: assume we have a video file path that can be used as preview
+    // Currently I have hardcoded this to "Preview.mov" on desktop for testing.
+    let preview_file = String::from(desktop_dir().unwrap().join("Preview.mov").to_str().unwrap());
+
+    // Create editor and pass on the preview file to it
+    crate::editor::init_editor(&app_handle, preview_file);
 
     // Update app state
     let state_mutex = app_handle.state::<Mutex<AppState>>();

--- a/src-tauri/src/editor/mod.rs
+++ b/src-tauri/src/editor/mod.rs
@@ -1,19 +1,28 @@
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, WindowBuilder, WindowUrl};
 
-pub fn init_editor(app: &AppHandle) {
-    let editor_win = WindowBuilder::new(app, "editor", WindowUrl::App("/editor".into()))
+pub fn init_editor(app: &AppHandle, video_file: String) {
+    let editor_url = format!("/editor?file={}", video_file);
+
+    let mut editor_win = WindowBuilder::new(app, "editor", WindowUrl::App(editor_url.into()))
         .title("Helmer Micro")
         .accept_first_mouse(true)
         .inner_size(800.0, 800.0)
-        .skip_taskbar(true)
         .always_on_top(true)
         .decorations(true)
         .resizable(false)
         .visible(true)
         .focused(true)
-        .center()
-        .build();
+        .center();
+
+    #[cfg(target_os = "macos")]
+    {
+        editor_win = editor_win
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true);
+    }
+
+    editor_win.build().expect("Failed to build editor window");
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/editor/mod.rs
+++ b/src-tauri/src/editor/mod.rs
@@ -27,6 +27,7 @@ pub fn init_editor(app: &AppHandle, video_file: String) {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExportOptions {
+    range: Vec<u32>,
     size: u32,
     fps: u32,
     speed: f32,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,7 +11,20 @@
   },
   "tauri": {
     "allowlist": {
-      "all": true
+      "all": true,
+      "fs": {
+        "scope": [
+          "$TEMP/**",
+          "$DESKTOP/**"
+        ]
+      },
+      "protocol": {
+        "all": false,
+        "asset": true,
+        "assetScope": [
+          "**"
+        ]
+      }
     },
     "bundle": {
       "active": true,

--- a/src/components/editor/Controls.tsx
+++ b/src/components/editor/Controls.tsx
@@ -11,8 +11,8 @@ const Label = ({ text, children }: {
 	</label>
 }
 
-export default function Controls({ submitHandler }: {
-	submitHandler: (data: { size: number, fps: number, speed: number, loop_gif: boolean, bounce: boolean }) => void
+export default function Controls({ exportHandler }: {
+	exportHandler: (data: { size: number, fps: number, speed: number, loop_gif: boolean, bounce: boolean }) => void
 }) {
 
 	const [size, setSize] = useState(1000);
@@ -69,7 +69,7 @@ export default function Controls({ submitHandler }: {
 			className="bg-[#444] text-white rounded-lg p-2"
 			onClick={e => {
 				e.preventDefault();
-				submitHandler({ size, fps, speed, loop_gif: loop, bounce })
+				exportHandler({ size, fps, speed, loop_gif: loop, bounce })
 			}}
 		/>
 	</form>

--- a/src/components/editor/Preview.tsx
+++ b/src/components/editor/Preview.tsx
@@ -2,9 +2,12 @@ import { useState, useEffect, useRef } from "react";
 import { convertFileSrc } from '@tauri-apps/api/tauri'
 import * as Slider from '@radix-ui/react-slider';
 
-export default function Preview() {
+export default function Preview({ selectedFrames, setSelectedFrames }: {
+	selectedFrames: number[],
+	setSelectedFrames: (e: number[]) => void
+}) {
 	const [totalFrames, setTotalFrames] = useState(0);
-	const [selectedFrames, setSelectedFrames] = useState([0, 200]);
+
 
 	const previewRef = useRef<HTMLVideoElement>(null);
 

--- a/src/components/editor/Preview.tsx
+++ b/src/components/editor/Preview.tsx
@@ -2,39 +2,35 @@ import { useState, useEffect, useRef } from "react";
 import { convertFileSrc } from '@tauri-apps/api/tauri'
 import * as Slider from '@radix-ui/react-slider';
 
-export default function Preview({ selectedFrames, setSelectedFrames }: {
+export default function Preview({
+	selectedFrames,
+	setSelectedFrames
+}: {
 	selectedFrames: number[],
 	setSelectedFrames: (e: number[]) => void
 }) {
+	const previewFps = 30; // Assume preview is 30 fps for now
+	const videoRef = useRef<HTMLVideoElement>(null) as React.MutableRefObject<HTMLVideoElement>;
 	const [totalFrames, setTotalFrames] = useState(0);
 
 
-	const previewRef = useRef<HTMLVideoElement>(null);
-
-	const previewFps = 30; // Assume 30 fps for now
-
 	const handleInput = (e: number[]) => {
 
-		// check which number is changing and update the video accordingly
+		// check which handle is changing and update preview
 		if (e[0] !== selectedFrames[0]) {
-			// @ts-expect-error
-			previewRef.current.currentTime = e[0] / previewFps;
+			videoRef.current.currentTime = e[0] / previewFps;
 		} else if (e[1] !== selectedFrames[1]) {
-			// @ts-expect-error
-			previewRef.current.currentTime = e[1] / previewFps;
+			videoRef.current.currentTime = e[1] / previewFps;
 		}
 
 		setSelectedFrames(e)
 	};
 
 	const handlePlayPause = () => {
-		// @ts-expect-error
-		if (previewRef.current.paused) {
-			// @ts-expect-error
-			previewRef.current.play();
+		if (videoRef.current.paused) {
+			videoRef.current.play();
 		} else {
-			// @ts-expect-error
-			previewRef.current.pause();
+			videoRef.current.pause();
 		}
 	}
 
@@ -44,16 +40,13 @@ export default function Preview({ selectedFrames, setSelectedFrames }: {
 		const previewPath = params.get("file");
 		const previewUrl = convertFileSrc(previewPath!);
 
-		// @ts-expect-error — Set the video source to the preview URL
-		previewRef.current.src = previewUrl;
-		// @ts-expect-error
-		previewRef.current.load();
+		// Set the source to the preview URL
+		videoRef.current.src = previewUrl;
+		videoRef.current.load();
 
-		// Get the duration (in seconds) after the video is loaded
-		// @ts-expect-error
-		previewRef.current.addEventListener('loadedmetadata', () => {
-			// @ts-expect-error
-			const duration = previewRef.current.duration;
+		// Get duration (in seconds) after the video is loaded
+		videoRef.current.addEventListener('loadedmetadata', () => {
+			const duration = videoRef.current.duration;
 			const frames = Math.floor(duration * previewFps);
 			setTotalFrames(frames);
 			setSelectedFrames([0, frames]);
@@ -63,16 +56,16 @@ export default function Preview({ selectedFrames, setSelectedFrames }: {
 
 	return <div className="w-[95%] h-fit rounded-xl overflow-hidden m-auto mt-0 mb-0 flex flex-col p-4 gap-4">
 		<video muted controls={false}
-			className="w-full object-cover rounded-md overflow-hidden h-[380px] border border-neutral-600" width={800} height={480} ref={previewRef}
+			className="w-full object-cover rounded-md overflow-hidden h-[380px] border border-neutral-600" width={800} height={480} ref={videoRef}
 			onClick={handlePlayPause}
 		/>
 
 		<Slider.Root
-			className="relative flex items-center select-none touch-none h-5"
-			value={selectedFrames}
 			min={0}
-			max={totalFrames}
 			step={1}
+			max={totalFrames}
+			value={selectedFrames}
+			className="relative flex items-center select-none touch-none h-5"
 			onValueChange={(e) => handleInput(e)}
 		>
 			<Slider.Track className="bg-black relative grow rounded-full h-[3px] w-full">

--- a/src/components/editor/Preview.tsx
+++ b/src/components/editor/Preview.tsx
@@ -24,6 +24,17 @@ export default function Preview() {
 		setSelectedFrames(e)
 	};
 
+	const handlePlayPause = () => {
+		// @ts-expect-error
+		if (previewRef.current.paused) {
+			// @ts-expect-error
+			previewRef.current.play();
+		} else {
+			// @ts-expect-error
+			previewRef.current.pause();
+		}
+	}
+
 	useEffect(() => {
 		// Extract preview video path from query params
 		const params = new URLSearchParams(window.location.search);
@@ -50,6 +61,7 @@ export default function Preview() {
 	return <div className="w-[95%] h-fit rounded-xl overflow-hidden m-auto mt-0 mb-0 flex flex-col p-4 gap-4">
 		<video muted controls={false}
 			className="w-full object-cover rounded-md overflow-hidden h-[380px] border border-neutral-600" width={800} height={480} ref={previewRef}
+			onClick={handlePlayPause}
 		/>
 
 		<Slider.Root

--- a/src/components/editor/Preview.tsx
+++ b/src/components/editor/Preview.tsx
@@ -1,23 +1,44 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { convertFileSrc } from '@tauri-apps/api/tauri'
 import * as Slider from '@radix-ui/react-slider';
 
 export default function Preview() {
 
+	const [previewVideo, setPreviewVideo] = useState<string>();
 	const [selectedFrames, setSelectedFrames] = useState([0, 200]);
 
-	const handleInput = (e) => {
+	const previewRef = useRef<HTMLVideoElement>(null);
+
+	const handleInput = (e: number[]) => {
 		console.log(e)
 		setSelectedFrames(e)
 	};
 
 	// TODO: Show the GIF preview here
-	// get preview video file
+
+	useEffect(() => {
+		// We have got the preview video file from query parameters
+		const params = new URLSearchParams(window.location.search);
+		const filePath = params.get("file");
+		const assetUrl = convertFileSrc(filePath!);
+		setPreviewVideo(assetUrl);
+	}, []);
+
+	useEffect(() => {
+		if (previewVideo) {
+			previewRef.current?.load()
+			console.log(previewRef.current?.duration);
+		}
+
+	}, [previewVideo])
+
 	// get total frames and map to slider max
-	// on slider change, update start and end frame
 	// on slider change, update preview video to show current frame
 
-	return <div className="bg-[#111111] w-[80%] h-fit rounded-xl overflow-hidden m-auto mt-0 mb-10 flex flex-col p-4 gap-4">
-		<img src="http://placekitten.com/1000/600" alt="" className="w-full" />
+	return <div className="w-[95%] h-fit rounded-xl overflow-hidden m-auto mt-0 mb-0 flex flex-col p-4 gap-4">
+		<video src={previewVideo} muted controls={false}
+			className="w-full object-cover rounded-md overflow-hidden h-[380px] border border-neutral-600" width={800} height={480} ref={previewRef}
+		/>
 
 		<Slider.Root
 			className="relative flex items-center select-none touch-none h-5"
@@ -27,8 +48,8 @@ export default function Preview() {
 			step={1}
 			onValueChange={(e) => handleInput(e)}
 		>
-			<Slider.Track className="bg-blackA7 relative grow rounded-full h-[3px] w-full">
-				<Slider.Range className="absolute bg-[yellow] rounded-full h-full" />
+			<Slider.Track className="bg-black relative grow rounded-full h-[3px] w-full">
+				<Slider.Range className="absolute bg-[aqua] rounded-full h-full" />
 			</Slider.Track>
 			<Slider.Thumb
 				className="block w-5 h-5 bg-white shadow-[0_2px_10px] shadow-blackA4 rounded-[10px] hover:bg-violet3 focus:outline-none focus:shadow-[0_0_0_5px] focus:shadow-blackA5"

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/tauri'
 import Preview from "./Preview";
 import Controls from "./Controls";
 
 export default function Editor() {
+
+	const [selectedFrames, setSelectedFrames] = useState([0, 200]);
 
 	const exportHandler = (options: {
 		size: number,
@@ -12,7 +15,10 @@ export default function Editor() {
 		bounce: boolean
 	}) => {
 		invoke('export_handler', {
-			options
+			options: {
+				range: selectedFrames,
+				...options,
+			}
 		}).then(() => {
 			console.log("export started")
 		})
@@ -20,8 +26,8 @@ export default function Editor() {
 
 	return (
 		<main className="w-full h-full flex flex-col bg-[#222] p-8 items-center">
-			<Preview />
-			<Controls submitHandler={exportHandler} />
+			<Preview setSelectedFrames={setSelectedFrames} selectedFrames={selectedFrames} />
+			<Controls exportHandler={exportHandler} />
 		</main>
 	);
 }

--- a/src/components/titlebar.astro
+++ b/src/components/titlebar.astro
@@ -1,0 +1,4 @@
+<div
+	data-tauri-drag-region
+	class="w-full absolute top-0 left-0 z-10 h-[32px]"
+/>

--- a/src/pages/editor.astro
+++ b/src/pages/editor.astro
@@ -1,8 +1,10 @@
 ---
 import Base from "../components/base.astro";
 import EditorReact from "../components/editor"
+import Titlebar from "../components/titlebar.astro";
 ---
 
 <Base>
+	<Titlebar />
 	<EditorReact client:load />
 </Base>


### PR DESCRIPTION
**✅ Done** 
1. Expect a video path from backend to show preview
2. Add all the editor controls on the frontend
3. Add a "false" titlebar to the editor (otherwise window can't be dragged on macOS)
4. Connect trimming control to preview video
5. Ensure trimmed frame range + export options are being sent to backend